### PR TITLE
add conformal cut for sim types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,7 @@
 /.vscode
 # Ignore tests directory
 /tests
+# Ignore venv
+.venv/*
 # Ignore .DS_Store
 *.DS_Store

--- a/opensipi/__init__.py
+++ b/opensipi/__init__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [tool.poetry]
 name = "opensipi"
-version = "0.1.8"
+version = "0.1.9"
 description = "An open-source Python3-based tool to automate signal integrity (SI) and power integrity (PI) related simulations."
 authors = ["Yansheng Wang <yanshengw@rivosinc.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
1. Add conformal cut for all sim types, requiring Sigrity 2024 and beyond.
2. Fixed the bug that conformal cut can only be done for the 1st design.