### PR TITLE
Rev0.2.1, harmonize the def of comp and cap ports

### DIFF
--- a/opensipi/__init__.py
+++ b/opensipi/__init__.py
@@ -2,4 +2,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/opensipi/sigrity_exec.py
+++ b/opensipi/sigrity_exec.py
@@ -838,7 +838,7 @@ class PowersiPdnExec:
 
     def __check_cap_model(self):
         """Check if SPICE models are used for a cap. The assumption
-        is that a SPICE model will be longer than 10 lines.
+        is that a SPICE model will be longer than 5 lines.
         """
         input_key = list(self.sim_input.keys())
         cap_model_lines = {}
@@ -866,7 +866,7 @@ class PowersiPdnExec:
                 for i_val in val:
                     if i_val[1] == 1:
                         warning_msg.append(f"Sim Key: {key} -> {i_val[0]} -> No models found")
-                    elif i_val[1] <= 10:
+                    elif i_val[1] <= 5:
                         warning_msg.append(
                             f"Sim Key: {key} -> {i_val[0]} -> No SPICE type models found"
                         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [tool.poetry]
 name = "opensipi"
-version = "0.2.0"
+version = "0.2.1"
 description = "An open-source Python3-based tool to automate signal integrity (SI) and power integrity (PI) related simulations."
 authors = ["Yansheng Wang <yanshengw@rivosinc.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Use the same way to define comp and cap ports. All comp ports are first disabled and then set up.
The way to determine whether a SPICE type cap model is used is based on how many lines exist in the model. If it's less than 5 lines but larger than 1 line. Then it's called no SPICE type model.